### PR TITLE
Add workflow to sync Alpine releases

### DIFF
--- a/.github/workflows/sync-alpine-tags.yml
+++ b/.github/workflows/sync-alpine-tags.yml
@@ -1,0 +1,76 @@
+name: Sync Alpine Tags
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync-tags:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Get Alpine releases
+        run: |
+          echo "Fetching Alpine releases..."
+          ALPINE_RELEASES=$(curl -s https://alpinelinux.org/releases.json \
+            | jq -r '.release_branches[].releases[].version' \
+            | sort -u -V)
+          ALPINE_RELEASES_FORMATTED=$(echo "$ALPINE_RELEASES" | tr '\n' ' ')
+          echo "alpine_releases=$ALPINE_RELEASES_FORMATTED" >> $GITHUB_ENV
+
+      - name: Get existing tags
+        run: |
+          git fetch --tags
+          EXISTING_TAGS=$(git tag -l)
+          EXISTING_TAGS_FORMATTED=$(echo "$EXISTING_TAGS" | tr '\n' ' ')
+          echo "existing_tags=$EXISTING_TAGS_FORMATTED" >> $GITHUB_ENV
+
+      - name: Process missing tags
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+          MIN_VERSION: 3.22.0
+        run: |
+          EXISTING_TAGS_PATTERN=" ${{ env.existing_tags }} "
+          PROCESSED=0
+
+          for version in ${{ env.alpine_releases }}; do
+            if [ "$(printf '%s\n%s\n' "$MIN_VERSION" "$version" | sort -V | head -n1)" != "$MIN_VERSION" ]; then
+              echo "Skipping version $version (older than $MIN_VERSION)"
+              continue
+            fi
+
+            if [[ "$EXISTING_TAGS_PATTERN" == *" $version "* ]]; then
+              echo "Tag $version already exists, skipping"
+              continue
+            fi
+
+            echo "Creating new tag: $version"
+            git tag "$version"
+            git push origin "$version"
+
+            echo "Triggering build for tag $version"
+            curl -X POST \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: token $GH_PAT" \
+              https://api.github.com/repos/${{ github.repository }}/actions/workflows/build.yml/dispatches \
+              -d '{"ref": "refs/tags/'"$version"'"}'
+
+            PROCESSED=$((PROCESSED+1))
+          done
+
+          echo "Process completed. Created $PROCESSED new tags."
+
+      - name: Summary
+        run: |
+          echo "# Alpine Tags Synchronization" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Alpine releases found: $(echo "${{ env.alpine_releases }}" | wc -w)" >> $GITHUB_STEP_SUMMARY
+          echo "- Existing tags: $(echo "${{ env.existing_tags }}" | wc -w)" >> $GITHUB_STEP_SUMMARY
+          echo "- New tags created: $(git tag -l | wc -w) - $(echo "${{ env.existing_tags }}" | wc -w)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- add scheduled workflow to sync Alpine Linux release tags starting from 3.22.0

## Testing
- `./run_tests.sh` *(fails: apk not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aefd1adce88322b9a0bb82adb3c22f